### PR TITLE
Fixed missing cell padding for compact post titles

### DIFF
--- a/winston/components/Links/PostLink/getPostContentWidth.swift
+++ b/winston/components/Links/PostLink/getPostContentWidth.swift
@@ -140,7 +140,7 @@ func getPostDimensions(post: Post, winstonData: PostWinstonData? = nil, columnWi
       }
     }
     
-    let compactTitleWidth = postGeneralSpacing + VotesCluster.verticalWidth + (showSelfPostThumbnails || extractedMedia != nil ? postGeneralSpacing + compactMediaSize.width : 0)
+    let compactTitleWidth = postGeneralSpacing + VotesCluster.verticalWidth + postGeneralSpacing + compactMediaSize.width
     
     let titleContentWidth = contentWidth - (compact ? compactTitleWidth : 0)
     


### PR DESCRIPTION
Fixes #309

Title width should likely be fixed regardless. `compactMediaSize` is also fixed even if there's no media.

![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 12 35 44](https://github.com/pankopan/winston/assets/152220723/659b0288-336b-466e-a474-990a88b1ce51)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 12 35 05](https://github.com/pankopan/winston/assets/152220723/9664cfd7-e0a0-414c-9b65-dd3f4974c7f8)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 12 34 43](https://github.com/pankopan/winston/assets/152220723/36408c01-1314-4892-8f2c-bfcc5f638087)
